### PR TITLE
for lfe-2.0 fix ierl state.env as lfe_shell:new_state()

### DIFF
--- a/apps/ierl/src/ierl_backend_lfe.erl
+++ b/apps/ierl/src/ierl_backend_lfe.erl
@@ -32,7 +32,7 @@ language() ->
 
 init(_Args) ->
     {ok, _} = application:ensure_all_started(lfe),
-    #state{env = lfe_env:new()}.
+    #state{env = lfe_shell:new_state("lfe", [])}.
 
 deps() ->
     [ierl_versions].
@@ -60,12 +60,11 @@ execute(Code, _Msg, State) ->
         {Res, NewState} =
             lfe_shell:run_string(binary_to_list(Code), State#state.env),
 
-        NewBindings = element(2, NewState),
         Res1 = jup_util:ensure_binary(lfe_io_pretty:term(Res)),
 
         Counter1 = Counter + 1,
 
-        {{ok, Res1}, Counter1, State#state{env = NewBindings, counter = Counter1}}
+        {{ok, Res1}, Counter1, State#state{env = NewState, counter = Counter1}}
     catch
         Type:Reason:Stacktrace ->
             Stacktrace1 = format_stacktrace(Stacktrace),


### PR DESCRIPTION
Hi, all.

I got an error when using lfe with jupyterlab.
I fixed this.

Cause:
I used the lfe_env record for ierl's env, but lfe 2.0 returns the lfe_shell:state record in lfe_shell:run_string().

How to fix:
I decided to store the lfe_shell:state record as it is in the env field of the state record in ierl_backend. 